### PR TITLE
Update install steps to explicitly use arctl daemon start

### DIFF
--- a/content/docs/install/docker.md
+++ b/content/docs/install/docker.md
@@ -23,18 +23,23 @@ To install agentregistry in a Kubernetes cluster instead, see the [Install in Ku
    curl -fsSL https://raw.githubusercontent.com/agentregistry-dev/agentregistry/main/scripts/get-arctl | bash
    ```
 
-2. Start the agentregistry daemon by running any `arctl` command, such as `arctl version`.
+2. Start the agentregistry daemon. This starts the Docker containers that power agentregistry.
    ```sh
-   arctl version
+   arctl daemon start
    ```
 
-   Example output when the agentregistry daemon starts for the first time:
+   Example output:
    ```console
    Starting agentregistry daemon...
    ✓ agentregistry daemon started successfully
    ```
 
-   Example output when the agentregistry daemon is already running:
+3. Verify the installation by checking the version.
+   ```sh
+   arctl version
+   ```
+
+   Example output:
    ```console
    arctl version 0.1.13
    Git commit: f193977
@@ -44,7 +49,7 @@ To install agentregistry in a Kubernetes cluster instead, see the [Install in Ku
    Server build date: 2026-01-25
    ```
 
-3. [Open the agentregistry UI](http://localhost:12121/) in your browser. The UI is automatically exposed on port `12121` when the daemon starts.
+4. [Open the agentregistry UI](http://localhost:12121/) in your browser. The UI is automatically exposed on port `12121` when the daemon starts.
 
    {{< reuse-image src="img/ar-local.png" width="800px" >}}
    {{< reuse-image-dark srcDark="img/ar-local-dark.png" width="800px" >}}

--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -24,23 +24,28 @@ To install agentregistry in a Kubernetes cluster instead, see the [Install in Ku
 
 ## Setup
 
-1. Install the agentregistry `arctl` binary on your local machine. The binary is automatically added to the `usr/local/bin/arctl` directory. 
-   ```
+1. Install the agentregistry `arctl` binary on your local machine. The binary is automatically added to the `/usr/local/bin/arctl` directory. 
+   ```sh
    curl -fsSL https://raw.githubusercontent.com/agentregistry-dev/agentregistry/main/scripts/get-arctl | bash
    ```
 
-2. Start the agentregistry daemon by running any `arctl` command, such as `arctl version`. 
+2. Start the agentregistry daemon. This starts the Docker containers that power agentregistry. 
    ```sh
-   arctl version
+   arctl daemon start
    ```
 
-   Example output when the agentregistry daemon starts: 
+   Example output: 
    ```console
    Starting agentregistry daemon...
    ✓ agentregistry daemon started successfully
    ```
 
-   Example output when the agentregistry daemon already runs:
+3. Verify the installation by checking the version. 
+   ```sh
+   arctl version
+   ```
+
+   Example output:
    ```console
    arctl version 0.1.13
    Git commit: f193977
@@ -48,10 +53,9 @@ To install agentregistry in a Kubernetes cluster instead, see the [Install in Ku
    Server version: 0.1.13
    Server git commit: f193977
    Server build date: 2026-01-25
-   Server or local version is not a valid semantic version, not sure if update require: 0.1.13 or 0.1.13
    ```
 
-3. [Open the agentregistry UI](http://localhost:12121/) in your browser. The UI is automatically exposed on port 12121 on your local machine when you start the agentregistry daemon. 
+4. [Open the agentregistry UI](http://localhost:12121/) in your browser. The UI is automatically exposed on port 12121 on your local machine when you start the agentregistry daemon. 
 
    {{< reuse-image src="img/ar-local.png" width="800px" >}}
    {{< reuse-image-dark srcDark="img/ar-local-dark.png" width="800px" >}}


### PR DESCRIPTION
Separates daemon startup into its own step so users explicitly start Docker containers with `arctl daemon start` before verifying with `arctl version`. Updated in both quickstart and docker install docs.