### PR TITLE
Revised framework content tests

### DIFF
--- a/.docs-test.toml
+++ b/.docs-test.toml
@@ -18,6 +18,11 @@ brand   = "oss"
 builtRoot = "./public"
 baseURL   = "/"
 
+# Hugo build log for hugo-warnings.spec. The Makefile targets and the CI build
+# step write the Hugo build output here; the spec scans it for ERROR / WARN
+# lines (filtered by [allowlists].hugoWarnings).
+buildLog  = "./.build.log"
+
 # Source-tree roots for author-side lints (e.g. curl-quotes scans markdown
 # directly). Narrowed to docs content so lints don't trip on the marketing
 # landing page.
@@ -30,26 +35,32 @@ scanRoots = [
 # no [versioning] block — version-aware specs detect the absence and skip
 # gracefully (same mechanism agw's standalone/unversioned docs rely on).
 
-[checks]
-# Smoke is for multi-product cross-runs (SMOKE_PRODUCT env); agr is a single
-# site, so skip. Cross-browser is opt-in and slow; run it manually when needed.
-smoke        = false
-crossBrowser = false
+# All checks default to enabled. No [checks] overrides are needed: agr runs the
+# full default set. (The former `smoke`/`crossBrowser` toggles were removed from
+# the harness — smoke folded into the `content` project scoped by CONTENT_DIR,
+# and cross-browser is now selected per Playwright project.)
 
 # Allowlists for known-benign noise that surfaces against real content (the
 # module's bundled fixture has none of this). Tighten as content is fixed.
 [allowlists]
+hugoWarnings = [
+  "\\.Site\\.Data was deprecated",
+  "'items' parameter of the 'tabs' shortcode is deprecated",
+]
 consoleErrors = [
   # Third-party analytics/chat (GA, GTM, Qualified) make backend calls on page
   # init that fail in the offline test environment, surfacing as a bare
   # "invalid_request" pageerror with no stack. Not fixable without a live
   # backend — suppress until those scripts are refactored to not throw on init.
   "invalid_request",
-  # Hextra's main.min.js null-derefs (reading 'removeAttribute' /
-  # 'addEventListener') on the /docs/ landing page, which suppresses the
-  # sidebar and so omits the toggle markup main.js expects. Same class of
-  # benign error agw fixed at source via hidden navbar stand-in elements;
-  # agr hasn't adopted that yet, so suppress here until it does.
-  "removeAttribute",
-  "addEventListener",
+  # NOTE: agr previously allowlisted two Hextra main.min.js null-dereferences
+  # (reading 'removeAttribute' / 'addEventListener') that fired on pages with no
+  # real sidebar (e.g. the /docs/ landing page), where main.js can't find the
+  # toggle markup it expects. Those are now FIXED at the source: hidden stand-in
+  # elements (.hextra-hamburger-menu wrapping an <svg>, and
+  # .hextra-sidebar-container) render on every page via _partials/custom/footer.html,
+  # so main.js no longer null-derefs. The allowlist entries were removed so this
+  # console guard is re-armed — if the stand-ins regress, the error surfaces here
+  # (and in the static "Hextra hamburger toggle target" guard in docs-theme-extras).
+  # Ported from the same fix in agw-oss.
 ]

--- a/.github/workflows/framework-tests.yml
+++ b/.github/workflows/framework-tests.yml
@@ -1,5 +1,18 @@
 # Hugo + Hextra docs-framework harness, run against agentregistry-oss's built site.
 #
+# One Hugo build feeds two Playwright projects (defined in docs-theme-extras'
+# playwright.config.ts):
+#   --project=static   layout / theme-behavior specs (render the theme)
+#   --project=content  scanners that depend on the consumer's real content
+#                      (markdown-leaks walks the built HTML for rendering
+#                      leaks; curl-quotes lints source markdown)
+# The `content` scanners are the reason this workflow's path filter includes
+# CONTENT paths (content/**), not just layout paths: a content-only PR must
+# still run the leak scan, since that is exactly the kind of PR that introduces
+# content rendering breaks. Both projects share the same build, so running the
+# (fast, mostly fixture-bound) layout specs on a content PR too costs almost
+# nothing — not worth a second workflow to avoid.
+#
 # The harness lives in solo-io/docs-theme-extras and is checked out at the
 # version pinned in go.mod (semver tag or pseudo-version). Layouts and tests
 # stay in lockstep — bumping the module pin is one PR that updates both.
@@ -17,6 +30,9 @@ name: Framework tests
 on:
   pull_request:
     paths:
+      # Content — so the `content` scanners run on content-only PRs.
+      - 'content/**'
+      # Layout / build inputs.
       - 'layouts/**'
       - 'static/**'
       - 'assets/**'
@@ -28,8 +44,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  framework-test-static:
-    name: Static checks
+  framework-test:
+    name: Static + content checks
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -92,25 +108,28 @@ jobs:
           # css.TailwindCSS, which shells out to the Tailwind CLI declared in
           # this repo's devDependencies. Install them so Hugo finds the binary.
           npm install
-          hugo --gc --minify
+          # Capture the build log so hugo-warnings.spec can scan it for ERROR /
+          # WARN lines; surface it and fail if the build itself fails.
+          hugo --gc --minify > .build.log 2>&1 || { cat .build.log; exit 1; }
 
       - name: Install harness dependencies
         working-directory: docs-theme-extras
         run: npm ci
 
-      - name: Run static specs
+      - name: Run static + content specs
         working-directory: docs-theme-extras
         env:
           DOCS_TEST_CONFIG: ${{ github.workspace }}/.docs-test.toml
         run: |
-          npx playwright test --project=static --reporter=list,html 2>&1 | tee playwright-output.txt
+          # One invocation runs both projects against the single build above.
+          npx playwright test --project=static --project=content --reporter=list,html 2>&1 | tee playwright-output.txt
 
       - name: Append summary to PR check
         if: always()
         working-directory: docs-theme-extras
         run: |
           {
-            echo "## Framework tests — static (informational)"
+            echo "## Framework tests (informational)"
             echo ""
             echo '```'
             tail -25 playwright-output.txt 2>/dev/null || echo "No test output captured."
@@ -121,6 +140,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: framework-test-static-report
+          name: framework-test-report
           path: docs-theme-extras/playwright-report
           retention-days: 7

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.25.1
 // docs-theme-extras declares the hextra import itself (pinned to v0.12.3), so
 // hextra is a transitive dependency and is not listed here — matching
 // agentgateway / kgateway / ambientmesh. Its checksums stay in go.sum.
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.7 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.25.1
 // docs-theme-extras declares the hextra import itself (pinned to v0.12.3), so
 // hextra is a transitive dependency and is not listed here — matching
 // agentgateway / kgateway / ambientmesh. Its checksums stay in go.sum.
-require github.com/solo-io/docs-theme-extras v0.1.15 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.25.1
 // docs-theme-extras declares the hextra import itself (pinned to v0.12.3), so
 // hextra is a transitive dependency and is not listed here — matching
 // agentgateway / kgateway / ambientmesh. Its checksums stay in go.sum.
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.4 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.25.1
 // docs-theme-extras declares the hextra import itself (pinned to v0.12.3), so
 // hextra is a transitive dependency and is not listed here — matching
 // agentgateway / kgateway / ambientmesh. Its checksums stay in go.sum.
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.5 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.25.1
 // docs-theme-extras declares the hextra import itself (pinned to v0.12.3), so
 // hextra is a transitive dependency and is not listed here — matching
 // agentgateway / kgateway / ambientmesh. Its checksums stay in go.sum.
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.6 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.18-beta.4 h1:C1kbPlAO6tP6vLNDGb0vksGT6MQpIerEaDZOOewIwfM=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.4/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1XkswDwsxQPfZiM1Fniaw=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1XkswDwsxQPfZiM1Fniaw=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.6 h1:+E0ZW1rmf8rnL3TaFgaIwW72HtCdJzuw1UEIdY2RPTc=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.6/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.7 h1:Z1WWb9ZCoJymUkh3d1e9akfVX2aGOIUTdPoEH26XvcQ=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.7/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18 h1:S3CGkTq4EjIj1PNqQXht1xtLLGTUqhWzIezycV6wP3s=
+github.com/solo-io/docs-theme-extras v0.1.18/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1Xk
 github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
 github.com/solo-io/docs-theme-extras v0.1.18-beta.6 h1:+E0ZW1rmf8rnL3TaFgaIwW72HtCdJzuw1UEIdY2RPTc=
 github.com/solo-io/docs-theme-extras v0.1.18-beta.6/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.7 h1:Z1WWb9ZCoJymUkh3d1e9akfVX2aGOIUTdPoEH26XvcQ=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.7/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1XkswDwsxQPfZiM1Fniaw=
 github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.6 h1:+E0ZW1rmf8rnL3TaFgaIwW72HtCdJzuw1UEIdY2RPTc=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.6/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.15 h1:ob7bNwoRcYPv7axlQ3CT/5q/++HH0EGMWsch7qZrNsA=
-github.com/solo-io/docs-theme-extras v0.1.15/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.4 h1:C1kbPlAO6tP6vLNDGb0vksGT6MQpIerEaDZOOewIwfM=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.4/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=


### PR DESCRIPTION
# Description

Config-only adoption of the updated docs-framework harness. Bumps
`docs-theme-extras` to `v0.1.18` and moves onto the harness's renamed
**`content`** Playwright project (replacing the old **`smoke`** project).

**What changed:**
- **Harness pin:** `docs-theme-extras` `v0.1.15` → `v0.1.18` (go.mod/go.sum).
- **`content` project:** `.docs-test.toml` updated (build-log `buildLog`,
  content scoping) and the workflow now runs `static` + `content` with content
  paths added to the `pull_request` filter so content-only PRs run the leak scan.

No content changes — this repo had no lint findings to fix.

# Change Type
/kind fix

# Changelog
```release-note
NONE
```