### PR TITLE
Bump docs-theme-extras to v0.1.21, add pipefail to framework-tests, added descriptions

### DIFF
--- a/.github/workflows/framework-tests.yml
+++ b/.github/workflows/framework-tests.yml
@@ -122,6 +122,11 @@ jobs:
           DOCS_TEST_CONFIG: ${{ github.workspace }}/.docs-test.toml
         run: |
           # One invocation runs both projects against the single build above.
+          # pipefail required: bare `run:` steps run as `bash -e {0}` without
+          # pipefail here, so `tee`'s exit (0) would mask a failing test suite and
+          # the step would go green. The `if: always()` summary/upload steps below
+          # already assume this step can fail.
+          set -o pipefail
           npx playwright test --project=static --project=content --reporter=list,html 2>&1 | tee playwright-output.txt
 
       - name: Append summary to PR check

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -2,7 +2,7 @@
 title: agentregistry
 linkTitle: Docs
 toc: false
-description: ""
+description: "Agentregistry is an open source, secure, centralized catalog for building, publishing, discovering, and governing AI artifacts across registries and GitHub repositories."
 # Explicitly cascade the docs layout key to every descendant. Hugo defaults
 # `type` to the section name ("docs") so pages render today, but making it
 # explicit hardens against that default changing and satisfies the framework

--- a/content/docs/about.md
+++ b/content/docs/about.md
@@ -1,7 +1,7 @@
 ---
 title: About agentregistry
 weight: 10
-description:
+description: "Learn what agentregistry is: an open source, centralized catalog for building, publishing, discovering, and governing AI artifacts across registries."
 ---
 
 Agentregistry is an open source, centralized AI artifact catalog that helps you build, package, publish, discover, and govern AI artifacts—including agents, skills, MCP servers, and prompts—spread across multiple container registries and GitHub repositories. It provides a single source of truth for the AI building blocks your teams are allowed to share, deploy, and compose into applications.

--- a/content/docs/agents/_index.md
+++ b/content/docs/agents/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Agents
 weight: 20
-description:
+description: "Build, run, publish, and deploy AI agents with agentregistry."
 ---

--- a/content/docs/agents/create.md
+++ b/content/docs/agents/create.md
@@ -1,7 +1,7 @@
 ---
 title: Create and run
 weight: 10
-description:
+description: "Create an agent and run it locally using agentregistry's built-in agent templates."
 ---
 
 Quickly create an agent and run it on your local machine with built-in agent templates.

--- a/content/docs/agents/deploy/_index.md
+++ b/content/docs/agents/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Deploy
 weight: 40
-description: "Deploy agents built with agentregistry to your target environment."
+description: "Deploy agents to your target environment."
 ---

--- a/content/docs/agents/deploy/_index.md
+++ b/content/docs/agents/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Deploy
 weight: 40
-description:
+description: "Deploy agents built with agentregistry to your target environment."
 ---

--- a/content/docs/agents/deploy/kubernetes.md
+++ b/content/docs/agents/deploy/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes
 weight: 20
-description: 
+description: "Deploy your agentregistry agent to a Kubernetes cluster."
 ---
 
 Deploy your agent to a Kubernetes cluster. 

--- a/content/docs/agents/deploy/kubernetes.md
+++ b/content/docs/agents/deploy/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes
 weight: 20
-description: "Deploy your agentregistry agent to a Kubernetes cluster."
+description: "Deploy an agent in your Kubernetes cluster."
 ---
 
 Deploy your agent to a Kubernetes cluster. 

--- a/content/docs/agents/mcp.md
+++ b/content/docs/agents/mcp.md
@@ -1,5 +1,6 @@
 ---
 title: Add MCP servers
+description: "Give an agent access to the tools exposed by an MCP server."
 weight: 50
 ---
 

--- a/content/docs/agents/publish.md
+++ b/content/docs/agents/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Publish
 weight: 20
-description: "Build and publish your agent image to agentregistry with the arctl agent build and publish commands."
+description: "Add your agent to the registry catalog."
 ---
 
 Build and publish your agent image in agentregistry by using the `arctl agent build` and `arctl agent publish` commands. 

--- a/content/docs/agents/publish.md
+++ b/content/docs/agents/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Publish
 weight: 20
-description:
+description: "Build and publish your agent image to agentregistry with the arctl agent build and publish commands."
 ---
 
 Build and publish your agent image in agentregistry by using the `arctl agent build` and `arctl agent publish` commands. 

--- a/content/docs/agents/skills.md
+++ b/content/docs/agents/skills.md
@@ -1,5 +1,6 @@
 ---
 title: Add skills
+description: "Give an agent access to skills published in agentregistry, loaded at runtime under the /skills folder."
 weight: 55
 ---
 

--- a/content/docs/agents/skills.md
+++ b/content/docs/agents/skills.md
@@ -1,6 +1,6 @@
 ---
 title: Add skills
-description: "Give an agent access to skills published in agentregistry, loaded at runtime under the /skills folder."
+description: "Give an agent access to skills that are published in the registry catalog."
 weight: 55
 ---
 

--- a/content/docs/install/_index.md
+++ b/content/docs/install/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Install
 weight: 15
-description:
+description: "Install agentregistry for local development or in a Kubernetes cluster."
 ---

--- a/content/docs/install/docker.md
+++ b/content/docs/install/docker.md
@@ -1,7 +1,7 @@
 ---
 title: Install with Docker
 weight: 10
-description:
+description: "Install agentregistry for local development with Docker to build, publish, and deploy AI artifacts."
 ---
 
 Use this guide to install agentregistry for local development with Docker. This approach is useful if you want to run agentregistry from your local machine, an on-prem environment, or a VM. Agentregistry is spun up using Docker containers and you can use this installation to build, publish, and deploy AI artifacts to your local environment and Kubernetes clusters.

--- a/content/docs/install/kubernetes.md
+++ b/content/docs/install/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: Install in Kubernetes
 weight: 20
-description:
+description: "Install agentregistry in a Kubernetes cluster with Helm for shared team access to a central artifact registry."
 ---
 
 Use this guide to install agentregistry in a Kubernetes cluster by using Helm. This approach is useful for team environments where multiple developers need shared access to a central artifact registry.

--- a/content/docs/mcp/_index.md
+++ b/content/docs/mcp/_index.md
@@ -1,5 +1,5 @@
 ---
 title: MCP 
 weight: 30
-description:
+description: "Build, run, publish, and deploy Model Context Protocol (MCP) servers with agentregistry."
 ---

--- a/content/docs/mcp/create.md
+++ b/content/docs/mcp/create.md
@@ -1,7 +1,7 @@
 ---
 title: Create and run
 weight: 10
-description:
+description: "Build and run MCP servers on your local machine with agentregistry."
 ---
 
 Quickly build and run MCP servers on your local machine.

--- a/content/docs/mcp/deploy/_index.md
+++ b/content/docs/mcp/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Deploy
 weight: 30
-description:
+description: "Deploy MCP servers built with agentregistry to your target environment."
 ---

--- a/content/docs/mcp/deploy/kubernetes.md
+++ b/content/docs/mcp/deploy/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes
 weight: 20
-description:
+description: "Deploy your agentregistry MCP server to a Kubernetes cluster."
 ---
 
 Deploy your agent to a Kubernetes cluster. 

--- a/content/docs/mcp/publish.md
+++ b/content/docs/mcp/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Publish
 weight: 20
-description:
+description: "Build your MCP server image and push it to agentregistry to share and deploy it anywhere."
 ---
 
 Build your MCP server image and push it to agentregistry so that you can start sharing the MCP server with other teams and deploying it to any environment. 

--- a/content/docs/mcp/publish.md
+++ b/content/docs/mcp/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Publish
 weight: 20
-description: "Build your MCP server image and push it to agentregistry to share and deploy it anywhere."
+description: "Add an MCP server to the registry catalog. "
 ---
 
 Build your MCP server image and push it to agentregistry so that you can start sharing the MCP server with other teams and deploying it to any environment. 

--- a/content/docs/mcp/tools.md
+++ b/content/docs/mcp/tools.md
@@ -1,7 +1,7 @@
 ---
 title: Add tools
 weight: 15
-description:
+description: "Add tools to your MCP server."
 ---
 
 Add tools to your MCP server.

--- a/content/docs/prompts/_index.md
+++ b/content/docs/prompts/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Prompts
 weight: 45
-description:
+description: "Create, publish, and manage reusable prompts with agentregistry."
 ---

--- a/content/docs/prompts/publish.md
+++ b/content/docs/prompts/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Create and publish
 weight: 10
-description:
+description: "Create a prompt and publish it to agentregistry."
 ---
 
 Quickly create a prompt and publish it to agentregistry.

--- a/content/docs/prompts/publish.md
+++ b/content/docs/prompts/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Create and publish
 weight: 10
-description: "Create a prompt and publish it to agentregistry."
+description: "Create a prompt and publish it to the registry catalog."
 ---
 
 Quickly create a prompt and publish it to agentregistry.

--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Get started
 weight: 5
-description:
+description: "Get started with agentregistry: install the CLI, then publish and pull your first AI artifact."
 ---
 
 Agentregistry is an open source, secure, and centralized AI artifact catalog that helps you build, package, publish, discover, and govern Docker images for AI artifacts, including agents, skills, and MCP servers that are spread across multiple container registries and GitHub repositories. It provides a centralized view of the images you allow your teams to share and deploy into their environments. 

--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Get started
 weight: 5
-description: "Get started with agentregistry: install the CLI, then publish and pull your first AI artifact."
+description: "Get started with agentregistry."
 ---
 
 Agentregistry is an open source, secure, and centralized AI artifact catalog that helps you build, package, publish, discover, and govern Docker images for AI artifacts, including agents, skills, and MCP servers that are spread across multiple container registries and GitHub repositories. It provides a centralized view of the images you allow your teams to share and deploy into their environments. 

--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Reference
 weight: 100
-description:
+description: "Reference documentation for agentregistry, including the arctl CLI."
 ---

--- a/content/docs/reference/cli/_index.md
+++ b/content/docs/reference/cli/_index.md
@@ -1,7 +1,7 @@
 ---
 title: CLI
 weight: 10
-description:
+description: "Command reference for the arctl CLI."
 ---
 
 

--- a/content/docs/reference/cli/arctl-agent-add-mcp.md
+++ b/content/docs/reference/cli/arctl-agent-add-mcp.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent add-mcp
+description: "Add an MCP server entry to an agent's agent.yaml file."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-add-prompt.md
+++ b/content/docs/reference/cli/arctl-agent-add-prompt.md
@@ -1,6 +1,6 @@
 ---
 title: arctl agent add-prompt
-description: "Add a prompt reference to an agent's agent.yaml file, resolved from the registry when the agent runs."
+description: "Add a prompt reference to an agent manifest."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-add-prompt.md
+++ b/content/docs/reference/cli/arctl-agent-add-prompt.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent add-prompt
+description: "Add a prompt reference to an agent's agent.yaml file, resolved from the registry when the agent runs."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-add-skill.md
+++ b/content/docs/reference/cli/arctl-agent-add-skill.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent add-skill
+description: "Add a skill to the agent manifest."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-build.md
+++ b/content/docs/reference/cli/arctl-agent-build.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent build
+description: "Build Docker images for an agent project created with arctl agent init."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-delete.md
+++ b/content/docs/reference/cli/arctl-agent-delete.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent delete
+description: "Delete an agent from the registry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-init.md
+++ b/content/docs/reference/cli/arctl-agent-init.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent init
+description: "Bootstrap a new agent project, specifying the ADK framework, language, and target directory."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-list.md
+++ b/content/docs/reference/cli/arctl-agent-list.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent list
+description: "List agents published to the registry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-publish.md
+++ b/content/docs/reference/cli/arctl-agent-publish.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent publish
+description: "Publish an agent to the registry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-run.md
+++ b/content/docs/reference/cli/arctl-agent-run.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent run
+description: "Run an agent project locally with Docker Compose."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-agent-show.md
+++ b/content/docs/reference/cli/arctl-agent-show.md
@@ -1,5 +1,6 @@
 ---
 title: arctl agent show
+description: "Show detailed information about an agent."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-completion.md
+++ b/content/docs/reference/cli/arctl-completion.md
@@ -1,5 +1,6 @@
 ---
 title: arctl completion
+description: "Generate shell autocompletion scripts for arctl."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-configure.md
+++ b/content/docs/reference/cli/arctl-configure.md
@@ -1,5 +1,6 @@
 ---
 title: arctl configure
+description: "Create the JSON configuration each client needs to connect to arctl."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-deployments-create.md
+++ b/content/docs/reference/cli/arctl-deployments-create.md
@@ -1,5 +1,6 @@
 ---
 title: arctl deployments create
+description: "Create a deployment for an agent or MCP server from the registry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-deployments-delete.md
+++ b/content/docs/reference/cli/arctl-deployments-delete.md
@@ -1,5 +1,6 @@
 ---
 title: arctl deployments delete
+description: "Delete a deployment by its ID and tear down its associated resources."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-deployments-list.md
+++ b/content/docs/reference/cli/arctl-deployments-list.md
@@ -1,5 +1,6 @@
 ---
 title: arctl deployments list
+description: "List all agent and MCP server deployments."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-deployments-show.md
+++ b/content/docs/reference/cli/arctl-deployments-show.md
@@ -1,5 +1,6 @@
 ---
 title: arctl deployments show
+description: "Show detailed information about a deployment, including its status, provider, and endpoint URL."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-embeddings-generate.md
+++ b/content/docs/reference/cli/arctl-embeddings-generate.md
@@ -1,5 +1,6 @@
 ---
 title: arctl embeddings generate
+description: "Generate embeddings for existing servers and agents to backfill or refresh them."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-embeddings.md
+++ b/content/docs/reference/cli/arctl-embeddings.md
@@ -1,5 +1,6 @@
 ---
 title: arctl embeddings
+description: "Manage semantic embeddings stored in agentregistry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-add-tool.md
+++ b/content/docs/reference/cli/arctl-mcp-add-tool.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp add-tool
+description: "Generate an MCP tool scaffold."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-build.md
+++ b/content/docs/reference/cli/arctl-mcp-build.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp build
+description: "Build an MCP server from the current project."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-delete.md
+++ b/content/docs/reference/cli/arctl-mcp-delete.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp delete
+description: "Delete an MCP server from agentregistry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-init-go.md
+++ b/content/docs/reference/cli/arctl-mcp-init-go.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp init go
+description: "Initialize a new MCP server project using the mcp-go framework."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-init-python.md
+++ b/content/docs/reference/cli/arctl-mcp-init-python.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp init python
+description: "Initialize a new MCP server project using the fastmcp-python framework."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-init.md
+++ b/content/docs/reference/cli/arctl-mcp-init.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp init
+description: "Initialize a new MCP server project with dynamic tool loading."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-list.md
+++ b/content/docs/reference/cli/arctl-mcp-list.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp list
+description: "List all Model Context Protocol (MCP) servers published in the registry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-publish.md
+++ b/content/docs/reference/cli/arctl-mcp-publish.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp publish
+description: "Publish an MCP server to the registry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-run.md
+++ b/content/docs/reference/cli/arctl-mcp-run.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp run
+description: "Run an MCP server locally."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-mcp-show.md
+++ b/content/docs/reference/cli/arctl-mcp-show.md
@@ -1,5 +1,6 @@
 ---
 title: arctl mcp show
+description: "Show detailed information about an MCP server."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-prompt-delete.md
+++ b/content/docs/reference/cli/arctl-prompt-delete.md
@@ -1,5 +1,6 @@
 ---
 title: arctl prompt delete
+description: "Delete a prompt version from agentregistry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-prompt-list.md
+++ b/content/docs/reference/cli/arctl-prompt-list.md
@@ -1,5 +1,6 @@
 ---
 title: arctl prompt list
+description: "List prompts published to agentregistry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-prompt-publish.md
+++ b/content/docs/reference/cli/arctl-prompt-publish.md
@@ -1,5 +1,6 @@
 ---
 title: arctl prompt publish
+description: "Publish a prompt to agentregistry from a plain text or YAML file."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-prompt-show.md
+++ b/content/docs/reference/cli/arctl-prompt-show.md
@@ -1,5 +1,6 @@
 ---
 title: arctl prompt show
+description: "Show details of a prompt published to agentregistry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-skill-build.md
+++ b/content/docs/reference/cli/arctl-skill-build.md
@@ -1,5 +1,6 @@
 ---
 title: arctl skill build
+description: "Build a skill as a Docker image from a local skill folder containing a SKILL.md file."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-skill-delete.md
+++ b/content/docs/reference/cli/arctl-skill-delete.md
@@ -1,5 +1,6 @@
 ---
 title: arctl skill delete
+description: "Delete a skill from agentregistry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-skill-init.md
+++ b/content/docs/reference/cli/arctl-skill-init.md
@@ -1,5 +1,6 @@
 ---
 title: arctl skill init
+description: "Initialize a new agentic skill project."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-skill-list.md
+++ b/content/docs/reference/cli/arctl-skill-list.md
@@ -1,5 +1,6 @@
 ---
 title: arctl skill list
+description: "List available skills in agentregistry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-skill-publish.md
+++ b/content/docs/reference/cli/arctl-skill-publish.md
@@ -1,5 +1,6 @@
 ---
 title: arctl skill publish
+description: "Publish a skill to the registry."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-skill-pull.md
+++ b/content/docs/reference/cli/arctl-skill-pull.md
@@ -1,5 +1,6 @@
 ---
 title: arctl skill pull
+description: "Pull a skill from agentregistry and extract its contents to a local directory."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-skill-show.md
+++ b/content/docs/reference/cli/arctl-skill-show.md
@@ -1,5 +1,6 @@
 ---
 title: arctl skill show
+description: "Show detailed information about a skill."
 weight: 10
 ---
 

--- a/content/docs/reference/cli/arctl-version.md
+++ b/content/docs/reference/cli/arctl-version.md
@@ -1,5 +1,6 @@
 ---
 title: arctl version
+description: "Display the version of the arctl CLI."
 weight: 10
 ---
 

--- a/content/docs/reference/vulnerabilities.md
+++ b/content/docs/reference/vulnerabilities.md
@@ -1,5 +1,6 @@
 ---
 title: Security Vulnerabilities
+description: "Learn how the agentregistry project handles the lifecycle of CVEs (Common Vulnerabilities and Exposures)."
 weight: 20
 ---
 

--- a/content/docs/skills/_index.md
+++ b/content/docs/skills/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Skills
 weight: 40
-description:
+description: "Build, publish, pull, and manage agentic skills with agentregistry."
 ---

--- a/content/docs/skills/publish.md
+++ b/content/docs/skills/publish.md
@@ -1,7 +1,7 @@
 ---
 title: Publish
 weight: 20
-description:
+description: "Publish skills to agentregistry so others can discover and pull them."
 ---
 
 Publish skills to agentregistry so others can discover and pull them.

--- a/content/docs/skills/pull.md
+++ b/content/docs/skills/pull.md
@@ -1,7 +1,7 @@
 ---
 title: Pull skills
 weight: 30
-description:
+description: "Pull a published skill from agentregistry and extract its contents to your local machine."
 ---
 
 Pull a published skill from agentregistry and extract its contents to your local machine.

--- a/content/docs/ui.md
+++ b/content/docs/ui.md
@@ -1,7 +1,7 @@
 ---
 title: Agentregistry UI
 weight: 80
-description:
+description: "Use the agentregistry UI to view AI artifact images, share them with your teams, and deploy them to your environment."
 ---
 
 Use the agentregistry UI to view AI artifact images, share them with your teams, and deploy them to your environment. 

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.25.1
 // docs-theme-extras declares the hextra import itself (pinned to v0.12.3), so
 // hextra is a transitive dependency and is not listed here — matching
 // agentgateway / kgateway / ambientmesh. Its checksums stay in go.sum.
-require github.com/solo-io/docs-theme-extras v0.1.19 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/solo-io/docs-theme-extras v0.1.19 h1:OzJtj8fy2/ywyriND98Nnet8RH+xfArbe1UmmcmzaQM=
 github.com/solo-io/docs-theme-extras v0.1.19/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.21 h1:wj9hx8n4/xTJpXUHA9ntWAclAdXf0+pZV2BBUc2zD0s=
+github.com/solo-io/docs-theme-extras v0.1.21/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=


### PR DESCRIPTION
- Pin docs-theme-extras to v0.1.21 (from v0.1.19) in go.mod/go.sum.
- Add `set -o pipefail` before the playwright `| tee` step in framework-tests.yml so a failing test suite can't be masked by tee's exit 0 and go green.