### PR TITLE
Agent readiness fixes

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -83,7 +83,7 @@ jobs:
             --config docs-link-checking/lychee.toml
             --root-dir "${{ github.workspace }}/public"
             --index-files index.html
-            --remap "^https://agentregistry\.dev/ file:///${{ github.workspace }}/public/"
+            --remap "^https://aregistry\.ai/ file:///${{ github.workspace }}/public/"
             --format json
             --user-agent curl/8.4.0
             --output "${{ github.workspace }}/artifacts/agentregistry-oss-links.json"
@@ -91,7 +91,7 @@ jobs:
           )
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # Skip external URLs on PRs; remaps still resolve agentregistry.dev
+            # Skip external URLs on PRs; remaps still resolve aregistry.ai
             # links to local files so internal links are checked.
             "${LYCHEE_COMMON[@]}" --exclude "^https?://"
           else

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://agentregistry.dev/
+baseURL: https://aregistry.ai/
 languageCode: en-us
 title: agentregistry
 
@@ -36,7 +36,7 @@ params:
     # across layouts (copy-markdown, llms.txt, page-to-markdown) that emit
     # absolute URLs which need to resolve when pasted outside the build's
     # preview URL.
-    prodHost: "https://agentregistry.dev"
+    prodHost: "https://aregistry.ai"
 
   theme:
     default: dark


### PR DESCRIPTION
Some https://agentregistry.dev instances need updated to https://aregistry.ai.